### PR TITLE
Add interactive script to save YouTube transcripts as PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is part of a locally hosted [n8n](https://n8n.io) automation pro
 - Cleans up timing markers and bracketed notes.
 - Trims the text to 17,000 characters to stay within n8n payload limits.
 - Outputs JSON for easy parsing in n8n.
+- Includes a standalone interactive script that saves transcripts as PDFs.
 
 ## Requirements
 
@@ -22,6 +23,16 @@ python YT_transcripts.py <video_url_or_id1> [<video_url_or_id2> ...]
 ```
 
 The script prints a JSON array describing each transcript. In a self-hosted n8n instance, an **Execute Command** node can run this script and pass its JSON output to later nodes for analysis or storage.
+
+### Interactive PDF script
+
+For a quick one-off transcript in PDF format, run:
+
+```bash
+python interactive_transcript_to_pdf.py
+```
+
+The script will prompt for a YouTube URL or video ID and create a `{video_id}_transcript.pdf` file in the current directory.
 
 ## Local n8n Integration
 

--- a/interactive_transcript_to_pdf.py
+++ b/interactive_transcript_to_pdf.py
@@ -1,0 +1,53 @@
+from youtube_transcript_api import YouTubeTranscriptApi
+from fpdf import FPDF
+import re
+from typing import Optional
+
+
+def extract_video_id(url_or_id: str) -> Optional[str]:
+    """Extract the 11-character video ID from a URL or return the ID if provided."""
+    match = re.search(r"(?:v=|\/)([0-9A-Za-z_-]{11})", url_or_id)
+    if match:
+        return match.group(1)
+    if re.match(r"^[0-9A-Za-z_-]{11}$", url_or_id):
+        return url_or_id
+    return None
+
+
+def fetch_transcript(video_id: str) -> str:
+    """Fetch and clean the transcript text for the given video ID."""
+    entries = YouTubeTranscriptApi().fetch(video_id)
+    text = " ".join(getattr(entry, "text", str(entry)) for entry in entries)
+    text = re.sub(r"\[.*?\]", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def save_pdf(text: str, filename: str) -> None:
+    """Save the provided text into a simple PDF file."""
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.set_font("Arial", size=12)
+    pdf.multi_cell(0, 10, text)
+    pdf.output(filename)
+
+
+def main() -> None:
+    url = input("Enter a YouTube video URL or ID: ").strip()
+    video_id = extract_video_id(url)
+    if not video_id:
+        print("Invalid YouTube URL or ID.")
+        return
+    try:
+        transcript = fetch_transcript(video_id)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error fetching transcript: {exc}")
+        return
+    filename = f"{video_id}_transcript.pdf"
+    save_pdf(transcript, filename)
+    print(f"Transcript saved to {filename}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add standalone `interactive_transcript_to_pdf.py` script to prompt for a video URL/ID and save its transcript as a PDF
- document the new interactive workflow in the README

## Testing
- `python -m py_compile interactive_transcript_to_pdf.py YT_transcripts.py`
- `HTTPS_PROXY="" HTTP_PROXY="" python interactive_transcript_to_pdf.py <<'EOF'
https://www.youtube.com/watch?v=H2cJC5A7nRA
EOF` *(fails: ProxyError 403 when contacting YouTube)*

------
https://chatgpt.com/codex/tasks/task_e_689c7e48f798833185128bdc95a6c496